### PR TITLE
Checking for 2000 megabytes limit and using 2017-latest-ubuntu tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN gcc -shared  -ldl -fPIC -o wrapper.so wrapper.c
 
 
 
-FROM mcr.microsoft.com/mssql/server
+FROM mcr.microsoft.com/mssql/server:2017-latest-ubuntu
 COPY --from=build0 /root/wrapper.so /root/
 
 

--- a/wrapper.c
+++ b/wrapper.c
@@ -12,15 +12,15 @@ int sysinfo(struct sysinfo *info){
     // we need the real sysinfo function address
     pt = dlsym(RTLD_NEXT,"sysinfo");
     //printf("pt: %x\n", *(char *)pt);
-    
+
     // call the real sysinfo system call
     int real_return_val=((real_sysinfo)pt)(info);
 
     // but then modify its returned totalram field if necessary
-    // because sqlserver needs to believe it has 2GiB physical 
-    // memory
-    if( info->totalram < 1024l * 1024l * 1024l * 2l){ // 2GiB
-        info->totalram = 1024l * 1024l * 1024l * 2l ;
+    // because sqlserver needs to believe it has "2000 megabytes"
+    // physical memory
+    if( info->totalram < 1000l * 1000l * 1000l * 2l){ // 2000 megabytes
+        info->totalram = 1000l * 1000l * 1000l * 2l ;
     }
 
     return real_return_val;


### PR DESCRIPTION
SQL Server passes the check with 2,000,000,000 bytes physical memory ("2000 megabytes" in proper IEC interpretation). A test confirmed that SQL Server starts with reported  2,000,000,000 bytes on 1 GiB machine.

It also looks like Microsoft is not updating :latest tag as it has older version and had been last updated 10 months ago vs. 3 weeks ago for :2017-latest-ubuntu.
mcr.microsoft.com/mssql/latest - "com.microsoft.version": "14.0.3038.14"
mcr.microsoft.com/mssql/server:2017-latest-ubuntu - "com.microsoft.version": "14.0.3192.2"